### PR TITLE
#15 tree_to_array

### DIFF
--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -198,6 +198,8 @@ int rbtree_erase(rbtree *t, node_t *p) {
 }
 
 int rbtree_to_array(const rbtree *t, key_t *arr, const size_t n) {
-  // TODO: implement to_array
+  int limit = 0;
+  int *pl= &limit;
+  to_array(t,t->root,arr,n,pl);
   return 0;
 }

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -197,6 +197,17 @@ int rbtree_erase(rbtree *t, node_t *p) {
   return 0;
 }
 
+// 재귀로 리턴하면서 넣기 ? 
+void *to_array(const rbtree *t,node_t *node,key_t *arr,const size_t n,int *limit)
+{
+  if (node != t->nil && *limit<n)
+  {
+    to_array(t,node->left,arr,n,limit);
+    arr[(*limit)++] = node -> key;
+    to_array(t,node->right,arr,n,limit);
+  }
+}
+
 int rbtree_to_array(const rbtree *t, key_t *arr, const size_t n) {
   int limit = 0;
   int *pl= &limit;


### PR DESCRIPTION
- #15 
- RB tree의 내용을 key 순서대로 주어진 array로 변환
- array의 크기는 n으로 주어지며 tree의 크기가 n 보다 큰 경우에는 순서대로 n개 까지만 변환
- array의 메모리 공간은 이 함수를 부르는 쪽에서 준비하고 그 크기를 n으로 알려줍니다.
---
관련 테스트 
- [X] `test_to_array_suite();`
- [X] `test_multi_instance();`
---
close #15 